### PR TITLE
modify templates to improve feedback

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -7,8 +7,8 @@
     xhr.setRequestHeader(<%= @helpers.escape header %>, <%= @helpers.escape value %>);
     <% end %>
     xhr.onreadystatechange = function () {
-      if (this.status == 200 && this.readyState == 4) {
-        alert(this.responseText);
+      if (this.readyState == 4) {
+        alert('Status: '+this.status+\nHeaders: '+JSON.stringify(this.getAllResponseHeaders())+'\nBody: '+this.responseText);
       }
     };
     xhr.send(<%= @helpers.escape @body.join('') %>);

--- a/nodejs.html
+++ b/nodejs.html
@@ -11,7 +11,10 @@ request({
   headers: {<%= ("#{@helpers.escape header}: #{@helpers.escape value}" for header,value of @headers).join(", ") %>}, <% end %>
   method: "<%= @method.toUpperCase() %>"
 }, function (error, response, body) {
-<% end %>  console.log("Reponse received", body);
+<% end %>  
+  console.log("Status", response.statusCode);
+  console.log("Headers", JSON.stringify(response.headers));
+  console.log("Reponse received", body);
 });
 
 </section>


### PR DESCRIPTION
Modified javascript and node.js templates to include HTTP.STATUSCODE and HTTP.RESPONSE.HEADERS in display of results.

Also dropped the use of this.status==200 on javascript XHR block so that results of 201, 204, etc. still get displayed.
