### PR TITLE
In Ruby 1.9 RubyGems are loaded in runtime by default.

### DIFF
--- a/ruby.html
+++ b/ruby.html
@@ -1,7 +1,7 @@
 <section name="ruby" class="ruby">
   <p class="ioDesc">In</p>
   <pre class="incoming brush:ruby">
-require 'rubygems'
+<% if RUBY_VERSION < "1.9" %>require 'rubygems'<% end %>
 require 'rest_client'
 
 <% if @body and @contentType is "application/x-www-form-urlencoded": %>values   = CGI::escape(<%= @helpers.escape @body.join('') %>)


### PR DESCRIPTION
Rant: It's a very sick idea to load RubyGems into runtime anyway, they do awful and unnecessary things. Well, it's the community standard, looks like Ruby is the new PHP, yay ... OK, RubyGems are getting better, but still, it's a buggy software and I remember case when app worked on localhost, but on the server it crashed due to some RubyGems bug. I should know, I've been debugging quite some RubyGems issues, have a commit in RubyGems itself too.
