### PR TITLE
Runtime fixes for C# Snippet.

### DIFF
--- a/csharp.html
+++ b/csharp.html
@@ -1,7 +1,13 @@
 <section name="csharp" class="csharp">
   <p class="ioDesc">Request</p>
-  <pre class="incoming"><code class="language-csharp">var request = System.Net.WebRequest.Create("<%= @apiUrl %><%= @url %>") as System.Net.HttpWebRequest;
-    request.Method = "<%= @method.toUpperCase() %>";
+  <pre class="incoming"><code class="language-csharp">
+
+  //Common testing requirement. If you are consuming an API in a sandbox/test region, uncomment this line of code ONLY for non production uses.
+  //System.Net.ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+  var request = System.Net.WebRequest.Create("<%= @apiUrl %><%= @url %>") as System.Net.HttpWebRequest;
+  request.KeepAlive = true;
+  request.Method = "<%= @method.toUpperCase() %>";
 <% if @contentType: %>
     request.ContentType = "<%= @contentType %>";
 <% end %>
@@ -9,6 +15,7 @@
     <% for header, value of @headers: %>
       <% header = header.toLowerCase() %>
       <% if header is 'accept': %>request.Accept = "<%= @helpers.escape value %>";
+      <% else if header is 'content-type': %>request.ContentType=<%= @helpers.escape value %>;
       <% else if header is 'connection': %>request.Connection = "<%= @helpers.escape value %>";
       <% else if header is 'content-length': %>request.ContentLength = "<%= @helpers.escape value %>";
       <% else if header is 'expect': %>request.Expect = "<%= @helpers.escape value %>";
@@ -26,17 +33,15 @@
 <% end %>
 <% if @body?.length > 0: %>
 <% if @method.toUpperCase() is 'POST' or @method.toUpperCase() is 'PUT' or @method.toUpperCase() is 'DELETE' or @body.length > 0: %>
-using (var writer = new System.IO.StreamWriter(request.GetRequestStream())) {
-      byte[] byteArray = System.Text.Encoding.UTF8.GetBytes(<%= @helpers.escape @body %>);
-      request.ContentLength = byteArray.Length;
-      writer.Write(byteArray);
-      writer.Close();
-    }
+
+byte[] byteArray = System.Text.Encoding.UTF8.GetBytes(<%= @helpers.escape @body %>);
+request.ContentLength = byteArray.Length;
+using (var writer = request.GetRequestStream()){writer.Write(byteArray, 0, byteArray.Length);}
 <% end %>
 <% else: %>
     request.ContentLength = 0;
 <% end %>
-string responseContent;
+string responseContent=null;
 using (var response = request.GetResponse() as System.Net.HttpWebResponse) {
   using (var reader = new System.IO.StreamReader(response.GetResponseStream())) {
     responseContent = reader.ReadToEnd();


### PR DESCRIPTION
Changes to make the c# snippet more accessible to a wider variety of skill level and resolve certain runtime issues. 

Added Content-Type to header loop to prevent improper attempt to add to Header Collection. 
Fixes attempt to write the content length to the request during the write process. 
Fixes issue where the bytes may not be written to underlying stream. 
Adds the common SSL certificate hook that can be uncommented by developer. 
