### PR TITLE
Update curl template

### DIFF
--- a/curl.html
+++ b/curl.html
@@ -1,8 +1,10 @@
 <section name="curl" class="curl">
   <p class="ioDesc">Request</p>
-  <pre class="incoming"><code class="language-bash">curl --include<% if @headers: %><% for header,value of @headers: %> --header <%= @helpers.escape "#{header}: #{value}" %><% end %> \
-    <% end %><% if @method is 'HEAD' : %> -I \
-    <% else if @method isnt 'GET' or @body: %> --request <%= @method %> \
+  <pre class="incoming"><code class="language-bash">curl --include \
+    <% if @method is 'HEAD' : %> -I \
+    <% else if @method isnt 'GET' or @body: %> --request <%= @method %><% end %> \
+     --url "<%= @apiUrl %><%= @url %>"<% if @headers: %><% for header,value of @headers: %> \
+     --header <%= @helpers.escape "#{header}: #{value}" %><% end %> \
     <% end %><% if @body: %> --data-binary "<%= @body.replace(/(['"])/g, "\\$1") %>" \
-    <% end %> "<%= @apiUrl %><%= @url %>"</code></pre>
+    <% end %></code></pre>
 </section>


### PR DESCRIPTION
Options are now aligned, and ordered based on HTTP appearance
Tested on http://blog.apiary.io/language-templates/ --- didn't know about it, well done!

Note: I understand if you'd like to go back to having no `--url` option. It didn't start like that, but I liked the readability :)
