### PR TITLE
use singlequotes for curl data and only escape singlequotes

### DIFF
--- a/curl.html
+++ b/curl.html
@@ -7,6 +7,6 @@
 <% if @headers: %><% for header,value of @headers: %>
      --header <%= @helpers.escape "#{header}: #{value}" %> \
 <% end %>
-<% end %><% if @body: %>     --data-binary "<%= @body.replace(/(['"])/g, "\\$1") %>" \
+<% end %><% if @body: %>     --data-binary '<%= @body.replace(/(')/g, "\\$1") %>' \
     <% end %> <%= @apiUrl %><%= @url %></code></pre>
 </section>


### PR DESCRIPTION
`curl` example data uses doublequotes for the data and then escapes double and singlequotes.

JSON data requires doublequotes, so it makes more sense to enclose it in single quotes.
