### PR TITLE
Better and simpler Python example

### DIFF
--- a/python.html
+++ b/python.html
@@ -1,26 +1,25 @@
+<%
+    hasHeaders = @helpers.isNotEmpty @headers
+    hasData = @method not in ['TRACE', 'GET', 'HEAD'] and @body
+%>
 <section name="python" class="python">
   <p class="ioDesc">Request</p>
-  <pre class="incoming"><code class="language-python">from urllib2 import Request, urlopen
-<% if @contentType is "application/json": %>
-from json import dumps
-<% else if @contentType is "application/x-www-form-urlencoded": %>
-from urllib import urlencode
-<% end %>
-<% if @contentType is "application/x-www-form-urlencoded" and @body: %>
-values = urlencode(<%= @body %>)
-<% else if @contentType is "application/json" and @body: %>
-values = dumps(<%= @body %>)
-<% else if @method isnt 'GET' and @body: %>
-values = <%= @helpers.escape @body %>
+  <pre class="incoming"><code class="language-python">from __future__ import print_function
+import requests
 
+<% if hasHeaders: %>
+headers = {
+<%= ("    #{@helpers.escape header}: u#{@helpers.escape value}" for header, value of @headers).join ",\n" %>
+
+}
 <% end %>
-<% if @helpers.isNotEmpty @headers: %>
-headers = {<%= ("#{@helpers.escape header}: #{@helpers.escape value}" for header,value of @headers).join(", ") %>}
+<% if hasData: %>
+data = ur"""<%= @body %>"""
 <% end %>
-request = Request("<%= @apiUrl %><%= @url %>"<% if @method isnt 'GET' and @body : %>, data=values<% end %><% if @helpers.isNotEmpty @headers: %>, headers=headers<% end %>)
-<% if @method not in ['GET', 'POST'] : %>
-request.get_method = lambda: '<%= @method %>'
-<% end %>
-response_body = urlopen(request).read()
-print response_body</code></pre>
+
+response = requests.<%= @method.toLowerCase() %>("<%= @apiUrl %><%= @url %>"<% if hasHeaders: %>,
+                      <%= (Array(@method.length).join " ") + "headers=headers" %><% end %><% if hasData: %>,
+                      <%= (Array(@method.length).join " ") + "data=data" %><% end %>)
+
+print(response.text)</code></pre>
 </section>


### PR DESCRIPTION
Aims of these changes are:
- simplify the example
- introduce the requests library http://docs.python-requests.org/, which is ubiquitous in Python ecosystem these days
- introduce Python2/Python3 compatibility (tested on both)
- fix minor issues with formatting and indentation
- remove unnecessary conversions of body payload according to Content-Type - we already get it as string, we can use it directly as string I suppose

This proposal should supersede both https://github.com/apiaryio/language-templates/tree/python-requests and https://github.com/apiaryio/language-templates/tree/python3 branches. It should also fix #5.

Also fixes https://trello.com/c/Zp06pT75/133-strange-indentation-in-python-examples-in-new-docs (internal).

cc @Almad 
