### PR TITLE
Updates for Swift

### DIFF
--- a/swift.html
+++ b/swift.html
@@ -4,8 +4,8 @@
 // import XCPlayground
 // XCPSetExecutionShouldContinueIndefinitely()
 
-var url = NSURL(string: "<%= @apiUrl %><%= @url %>")
-var request = NSMutableURLRequest(URL: url)
+let url = NSURL(string: "<%= @apiUrl %><%= @url %>")
+let request = NSMutableURLRequest(URL: url)
 
 request.HTTPMethod = "<%= @method.toUpperCase() %>"
 
@@ -19,8 +19,8 @@ request.addValue(<%= @helpers.escape value %>, forHTTPHeaderField: <%= @helpers.
 request.HTTPBody = <%= @helpers.escape @body %>.dataUsingEncoding(NSUTF8StringEncoding);
 <% end %>
 
-var session = NSURLSession.sharedSession()
-var task = session.dataTaskWithRequest(request) { (data: NSData!, response: NSURLResponse!, error: NSError!) in
+let session = NSURLSession.sharedSession()
+let task = session.dataTaskWithRequest(request) { (data: NSData!, response: NSURLResponse!, error: NSError!) in
 
     if error != nil {
         // Handle error...


### PR DESCRIPTION
- Updates to be compatible with Swift 1.0, previous it was using a syntax from an early beta.
- Uses `let` instead of `var` because these values are not changed.
