### PR TITLE
Improve java template

### DIFF
--- a/java.html
+++ b/java.html
@@ -21,18 +21,15 @@ import javax.ws.rs.core.Response;
 Client client = ClientBuilder.newClient();
 
 <% if @method.toUpperCase() is 'POST' or @method.toUpperCase() is 'PUT' : %>
-<% if @body?.length == 0: %>
-<% body = "" %>
-<% end %>
 <% switch @helpers.getContentType @headers : %>
 <% when 'application/json' : %>
-Entity payload = Entity.json(<%= if @body then @helpers.escape(@body) else "" %>);
+Entity payload = Entity.json(<%= if @body then @helpers.escape(@body) else '""' %>);
 <% end %>
 <% when 'application/xml' : %>
-Entity payload = Entity.xml(<%= if @body then @helpers.escape(@body) else "" %>);
+Entity payload = Entity.xml(<%= if @body then @helpers.escape(@body) else '""' %>);
 <% end %>
 <% else : %>
-Entity&lt;String&gt; payload = Entity.text(<%= if @body then @helpers.escape(@body) else "" %>);
+Entity&lt;String&gt; payload = Entity.text(<%= if @body then @helpers.escape(@body) else '""' %>);
 <% end %>
 <% end %>
 <% end %>
@@ -41,7 +38,9 @@ Response response = client.target("<%= @apiUrl %>")
   .request("<%- @helpers.getContentType @headers %>")
 <% if @headers and @helpers.isNotEmpty @headers: %>
 <% for header, value of @headers: %>
+<% if header.toLowerCase() != 'content-type' : %>
   .header(<%= @helpers.escape header %>, <%= @helpers.escape value %>)
+<% end %>
 <% end %>
 <% end %>
 <% if @method.toUpperCase() is 'POST' or @method.toUpperCase() is 'PUT': %>


### PR DESCRIPTION
After seeing it online I found some errors.

However, I don't understand some things, I don't know if this is the better place to discuss them.

Url Params are replaced in curl template, but not in java template. And I don't see why. The code in the template is the same.
I see the template is different from what it's on github as the request have : "MediaType.APPLICATION_JSON_TYPE"

It should be without the quotes, and depending on the content-type, it can be MediaType.APPLICATION_JSON_TYPE or MediaType.APPLICATION_XML_TYPE or MediaType.APPLICATION_FORM_URLENCODED.. etc with all the possible media types. I put there the actual content-type string specified in apiary and if it's a valid content-type it should work, the MediaType variables are just constants for that media type strings.
