### PR TITLE
Fixed language rendering failing in case of null body

### DIFF
--- a/csharp.html
+++ b/csharp.html
@@ -34,6 +34,9 @@ using (var httpClient = new HttpClient{ BaseAddress = baseAddress })
       {
         <% end: %>
         <% else: %>
+        <% if !@body?: %>
+        <% @body = "" %>
+        <% end: %>
         <% if @content_type? : %>
         using (var content = new StringContent("<%- @helpers.escape @body %>", System.Text.Encoding.Default, "<%- @content_type %>"))
         <% else : %>


### PR DESCRIPTION
Adding a null-check into body for legacy blueprint will prevent template rendering errors.