### PR TITLE
[Java Code Example] Fix an issue with relative paths

### DIFF
--- a/java.html
+++ b/java.html
@@ -34,8 +34,7 @@ Entity&lt;String&gt; payload = Entity.text(<%= if @body then @helpers.escape(@bo
 <% end %>
 <% end %>
 <% end %>
-Response response = client.target("<%= @apiUrl %>")
-  .path("<%= @url %>")
+Response response = client.target("<%= @apiUrl %><%= @url %>")
 <% switch @helpers.getContentType @headers : %>
 <% when 'application/json' : %>
   .request(MediaType.APPLICATION_JSON_TYPE)


### PR DESCRIPTION
When the path has a leading slash and the base HOST contains a path Java will join the path and host differently to how Apiary does. 
- `https://crm-staging.mycontacts.io/api/v2`
- `/notes?offset=0&limit=10`

When joining the above, it will result in `https://crm-staging.mycontacts.io/notes?offset=0&limit=10` which is not the correct URI.
